### PR TITLE
activate GH page, relocate content to index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,153 @@
+#### Using this Handbook
+This handbook provides an overview of our company, what drives us, and how we operate. After reading this handbook, reach out to your manager to clarify any questions you may have. We have done our best to give you a glimpse into Enzyme; let us know if you feel something is missing. 
+
+#### What Matters to Us
+Enzyme was started to help companies get cutting edge technology to patients faster. We want to be open and transparent with our customers, and we help educate them so they can deliver the best product.
+
+#### Why Enzyme?
+After spending a decade each in the medical device industry, both Jared and Jacob grew exhausted with the status quo with respect to day-to-day QMS activities and submission generation. 
+
+Jacob used, on average, 5 different QMS software tools for day-to-day tasks (e.g. different tools for various elements of the QMS), and many users either 1) had partial/no access to all systems or 2) had significant difficulty using several systems due to infrequent access. This resulted in delays to getting work done on the order of multiple weeks/year for the broader team all supporting one project. Multiply this by thousands of projects in a large organization, and this translates into a significant resource drain and project delays.
+
+Jared co-founded a consulting firm before Enzyme that specifically aided companies in submission generation. While doing that, he learned of the immense waste of resources that companies invested in submission writing. 
+
+Both Jared and Jacob share a vision of a unifying QMS tool that simplifies and streamlines numerous workflows and assists in document creation through auto-generated Machine Learning & Natural Language Processing driven features.
+
+Too often good product ideas fail to commercialize due to what seems to be an overwhelming compliance and regulatory burden. The Enzyme cloud-hosted QMS greatly reduces the work needed to accomplish the same deliverables. Per its namesake, Enzyme acts as a catalyst, or force-multiplier, to help get products to market faster.
+
+#### Our Mission
+Enzyme's mission is to help life science companies commercialize faster without compromising patient care. We foster a culture of quality through modern software tools and expert guidance.  
+
+Our goal is to reduce the time and cost life science companies spend during the product development life cycle. Through our product, education, and support, we help companies commercialize faster. 
+
+#### Enzyme At A Glance
+
+- Founded: 2017
+- Founders: Jacob Graham, Jared Seehafer
+- Principal Investors: Y Combinator, Rock Health, Refactor Capital, DC VC (Data Collective), SOMA Capital
+- Current Offerings: Enzyme QMS, Quality as a Service, Regulatory Services
+
+
+#### What We Offer To Customers
+Enzyme offers a Quality Management System (QMS) as well as services to customers. 
+
+Software, content & services that make getting medical technology to market radically easier.
+
+##### QMS Web Application
+A SaaS application that encodes a depth of quality & regulatory business processes that is thoughtfully integrated & friendly to novices and pros alike.
+
+##### Quality System Document Library
+A Full QMS set of procedures compliant to regulations & standards to which medical device companies must comply.
+
+##### Services
+For strategic accounts, we offer Regulatory and/or Quality consulting services, or “RaaS” and “QaaS” respectively). Through the Quality services, we provide support to companies as they set up their QMS and train their users. In addition we also can audit their company to ensure they are ready for FDA inspections and Notified Body audits. 
+
+As part of our regulatory services, we can help companies prepare their pre-submissions and full submissions for the FDA or a Notified Body (the FDA equivalents in the European Union). 
+
+#### How We Operate
+Enzyme is a Remote First organization. Processes and tooling are set up to ensure a high level of transparency and accountability across the organization; regardless of whether an employee is on-site or remote. 
+
+Employees local to the SF Bay Area have the option to work from HQ on a daily basis. However, employees can work remotely from home, a coffee shop, or wherever they are most efficient, provided their work is getting done. 
+
+For the 100% remote team members, they can work from anywhere during business hours as long as they are available online for calls. 
+
+#### Performance Mangement (aka Objectives & Keys Results, OKRs)
+* Each quarter the team will develop OKRs and lock them in the [Goals Feature of ClickUp](https://app.clickup.com/1246867/goals/)
+    * [HOWTO guide](https://www.youtube.com/watch?v=XplWt1eKPwE)
+* Updates will be made continously, asynchronously. Work streams can be associated to goals when appropriate.
+* Occassionally during an all-hands progress to plan will be discussed, blockers identified and triaged.
+
+
+#### Our Office
+* Enzyme HQ (headquarters): 360 Langton St, Suite 100, San Francisco, CA. 
+
+##### Focused Work and Asynchronous Communication
+- We support being in “in the zone” ([deep focused work](https://www.youtube.com/watch?v=ZD7dXfdDPfg))
+- We capture and track work in organized tasks
+- We communicate openly in shared digital forums (slack)
+
+Our employees work all sorts of different hours and from many global locations. This makes it hard to enforce a lot of tightly-coupled workflows during the day, but that’s a feature not a bug. Most of the work we do at Enzyme shouldn’t require us to be in constant communication throughout the entire day.
+
+We believe HIGHLY in the lesson of this cartoon: https://heeris.id.au/2013/this-is-why-you-shouldnt-interrupt-a-programmer/
+
+It’s far better for everyone’s concentration and sanity if we collaborate as though most things will get an answer eventually, but not necessarily right this second. The preferred first choice of action should be to post a message, a to-do, or a document about what we need explained or need to know. Then others can respond when they’re available.
+
+There are exceptions. Extended, synchronous collaborations sometimes are needed. We use Slack, Zoom, or in-person collaboration when appropriate. 
+
+Teams that collaborate heavily should plan for more overlap. Async should bias for deep  (aka Deep Work) concentration time, improving productivity.
+
+* Communication Norms    
+We use Slack as our main tool for communication. During business hours, all employees should be available via Slack. 
+
+* AFK (away from keyboard)    
+Life happens, just notify your team on Slack that you won’t be available and for approximately how long.
+
+#### Enzyme IRL
+
+Twice a year (summer and winter) we conduct a team offsite. This is an opportunity
+for employees to socialize and better get to know one another,
+to step away from daily tasks to discuss company goals, and
+strengthen teams and the company as a whole. 
+
+
+#### Tools we Use
+To successfully build our product, there are several tools we use on a daily basis.
+
+- ClickUp    
+Goals & work streams (other than engineering) are tracked in ClickUp to log and track projects for Marketing, Customer Success, Sales, Consulting, and Quality.
+
+ - Github    
+Github hosts our repository and our code. We have daily calls where we review the Github board and the issues the developers are working on. 
+
+- Slack    
+We use slack daily to communicate within the team and some of our customers. In support of Remote-First, async culture, please use appropriately scoped Slack channels whenever possible.
+
+**Even conversations amongst two-people, in the office, might take place over Slack to record it for posterity and broadcast to remote teams.**
+
+Updates for structured projects are entered into ClickUp, and when appropriate that project will auto-post to a Slack channel.
+
+- Zoom    
+Zoom is the video conferencing tool we use both internally and with our customers. Make sure to have it set up on your computer prior to client calls.
+
+- G Suite   
+We use Gmail and Google Calendar, and much of our documentation is hosted on Google Drive. 
+
+- Microsoft Office Suite    
+We use Office products such as Word and PowerPoint for certain internal purposes and with certain customers.
+
+- Figma       
+Figma is the design tool we use to create mocks for our product.
+
+- Webflow     
+We use Webflow as content management system (CMS)
+
+- Intercom    
+We use Intercom to manage customer leads on our website and handle questions in-app. Intercom also hosts our support center. 
+
+
+#### Compensation & Benefits 
+Enzyme provides 
+- competitive base compensation (distributed on the 15th & last business day of the month)
+- equity compensation
+- medical, dental and vision insurance -- 100% premium paid for employee and 50% premium pad for dependents
+- life insurance
+- 401k (contributions made every pay period)
+- paid time off  
+
+#### Perks
+- standing Desks - In-office we have adjustable desks so suit your ergonomic needs.
+- team offsite
+- catered lunches, snacks & beverages
+- flexible work hours, locations
+- commuter benefits
+- personal gear stipend (~$200)
+
+#### Standard Holidays
+- New Years Day
+- Memorial Day
+- US Labor Day
+- US July 4th
+- Thanksgiving
+- Christmas
+
+


### PR DESCRIPTION
Moving to the approved handbook content to a GH pages to keep it public (& prettier). 

This allows us to take the issue management/PR commenting process private. To encourage more rigorous/active dialog.